### PR TITLE
Moving PublishedGradleVersionsWrapper to a declarative OSGi service

### DIFF
--- a/org.eclipse.buildship.core/.project
+++ b/org.eclipse.buildship.core/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/org.eclipse.buildship.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.core.expressions,
  com.google.gson;bundle-version="[2.7.0,3.0.0)",
  org.eclipse.buildship.compat;visibility:=reexport
 Bundle-ActivationPolicy: lazy
-Import-Package: org.slf4j;version="1.7.2"
+Import-Package: org.osgi.service.component.annotations;version="1.3.0";resolution:=optional,
+ org.slf4j;version="1.7.2"
 Export-Package: org.eclipse.buildship.core,
  org.eclipse.buildship.core.internal;x-friends:="org.eclipse.buildship.ui,org.eclipse.buildship.kotlin",
  org.eclipse.buildship.core.internal.configuration;x-friends:="org.eclipse.buildship.ui,org.eclipse.buildship.kotlin",
@@ -46,3 +47,4 @@ Export-Package: org.eclipse.buildship.core,
  org.eclipse.buildship.core.internal.util.variable;x-friends:="org.eclipse.buildship.ui,org.eclipse.buildship.kotlin",
  org.eclipse.buildship.core.internal.workspace;x-friends:="org.eclipse.buildship.ui,org.eclipse.buildship.kotlin",
  org.eclipse.buildship.core.invocation
+Service-Component: OSGI-INF/org.eclipse.buildship.core.internal.util.gradle.PublishedGradleVersionsWrapper.xml

--- a/org.eclipse.buildship.core/OSGI-INF/org.eclipse.buildship.core.internal.util.gradle.PublishedGradleVersionsWrapper.xml
+++ b/org.eclipse.buildship.core/OSGI-INF/org.eclipse.buildship.core.internal.util.gradle.PublishedGradleVersionsWrapper.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.buildship.core.internal.util.gradle.PublishedGradleVersionsWrapper">
+   <property name="service.ranking" type="Integer" value="1"/>
+   <service>
+      <provide interface="org.eclipse.buildship.core.internal.util.gradle.PublishedGradleVersionsWrapper"/>
+   </service>
+   <implementation class="org.eclipse.buildship.core.internal.util.gradle.PublishedGradleVersionsWrapper"/>
+</scr:component>

--- a/org.eclipse.buildship.core/build.properties
+++ b/org.eclipse.buildship.core/build.properties
@@ -6,7 +6,8 @@ bin.includes = .,\
                META-INF/,\
                about.html,\
                plugin.xml,\
-               .options
+               .options,\
+               OSGI-INF/org.eclipse.buildship.core.internal.util.gradle.PublishedGradleVersionsWrapper.xml
 src.includes = plugin.xml,\
                schema/,\
                build.properties,\

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersionsWrapper.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersionsWrapper.java
@@ -18,58 +18,60 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-
+import org.osgi.service.component.annotations.Component;
 import org.eclipse.buildship.core.internal.CorePlugin;
 import org.eclipse.buildship.core.internal.util.gradle.PublishedGradleVersions.LookupStrategy;
 
 /**
- * Wraps the {@link PublishedGradleVersions} functionality in a background job that handles all
- * exceptions gracefully. If an exception occurs while calling the underlying
- * {@link PublishedGradleVersions} instance, default version information is provided. This handles,
- * for example, those scenarios where the versions cannot be retrieved because the user is behind a
- * proxy or offline.
+ * Wraps the {@link PublishedGradleVersions} functionality in a background job
+ * that handles all exceptions gracefully. If an exception occurs while calling
+ * the underlying {@link PublishedGradleVersions} instance, default version
+ * information is provided. This handles, for example, those scenarios where the
+ * versions cannot be retrieved because the user is behind a proxy or offline.
  */
+@Component(property = { "service.ranking:Integer=1" }, service = PublishedGradleVersionsWrapper.class)
 public final class PublishedGradleVersionsWrapper {
 
-    private final AtomicReference<PublishedGradleVersions> publishedGradleVersions;
+	private final AtomicReference<PublishedGradleVersions> publishedGradleVersions;
 
-    public PublishedGradleVersionsWrapper() {
-        this.publishedGradleVersions = new AtomicReference<PublishedGradleVersions>();
-        new LoadVersionsJob().schedule();
-    }
+	public PublishedGradleVersionsWrapper() {
+		this.publishedGradleVersions = new AtomicReference<PublishedGradleVersions>();
+		new LoadVersionsJob().schedule();
+	}
 
-    public List<GradleVersion> getVersions() {
-        PublishedGradleVersions versions = this.publishedGradleVersions.get();
-        return versions != null ? versions.getVersions() : ImmutableList.of(GradleVersion.current());
-    }
+	public List<GradleVersion> getVersions() {
+		PublishedGradleVersions versions = this.publishedGradleVersions.get();
+		return versions != null ? versions.getVersions() : ImmutableList.of(GradleVersion.current());
+	}
 
-    /**
-     * Loads the published Gradle versions in the background.
-     * @author Stefan Oehme
-     */
-    private final class LoadVersionsJob extends Job {
+	/**
+	 * Loads the published Gradle versions in the background.
+	 * 
+	 * @author Stefan Oehme
+	 */
+	private final class LoadVersionsJob extends Job {
 
-        public LoadVersionsJob() {
-            super("Loading available Gradle versions");
-            setSystem(true);
-        }
+		public LoadVersionsJob() {
+			super("Loading available Gradle versions");
+			setSystem(true);
+		}
 
-        @Override
-        protected IStatus run(IProgressMonitor monitor) {
-            try {
-                PublishedGradleVersions versions = PublishedGradleVersions.create(LookupStrategy.REMOTE_IF_NOT_CACHED);
-                PublishedGradleVersionsWrapper.this.publishedGradleVersions.set(versions);
-            } catch (RuntimeException e) {
-                CorePlugin.logger().warn("Could not load Gradle version information", e);
-            }
-            return Status.OK_STATUS;
-        }
+		@Override
+		protected IStatus run(IProgressMonitor monitor) {
+			try {
+				PublishedGradleVersions versions = PublishedGradleVersions.create(LookupStrategy.REMOTE_IF_NOT_CACHED);
+				PublishedGradleVersionsWrapper.this.publishedGradleVersions.set(versions);
+			} catch (RuntimeException e) {
+				CorePlugin.logger().warn("Could not load Gradle version information", e);
+			}
+			return Status.OK_STATUS;
+		}
 
-        @Override
-        protected void canceling() {
-            Thread.currentThread().interrupt();
-        }
+		@Override
+		protected void canceling() {
+			Thread.currentThread().interrupt();
+		}
 
-    }
+	}
 
 }


### PR DESCRIPTION
With this change the PublishedGradleVersionsWrapper is published as
declarative OSGi service instead registering it via the activator.

For #1151

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
