### PR TITLE
Fix local mac build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ project.assembleTargetPlatform.doLast {
                     '-p2.ws', Constants.ws,
                     '-p2.arch', Constants.arch,
                     '-roaming',
+                    '-vm', System.getProperty('java.home') + '/bin/java',
                     '-nosplash')
         }
 

--- a/buildSrc/src/main/groovy/eclipsebuild/BuildDefinitionPlugin.groovy
+++ b/buildSrc/src/main/groovy/eclipsebuild/BuildDefinitionPlugin.groovy
@@ -398,6 +398,7 @@ class BuildDefinitionPlugin implements Plugin<Project> {
                     '-roaming',
                     '-nosplash',
                     '-consoleLog',
+                    '-vm', System.getProperty('java.home') + '/bin/java',
                     '-vmargs', '-Declipse.p2.mirror=false')
 
             ignoreExitValue = true
@@ -423,6 +424,7 @@ class BuildDefinitionPlugin implements Plugin<Project> {
                     '-roaming',
                     '-nosplash',
                     '-consoleLog',
+                    '-vm', System.getProperty('java.home') + '/bin/java',
                     '-vmargs', '-Declipse.p2.mirror=false')
         }
     }

--- a/buildSrc/src/main/groovy/eclipsebuild/TestBundlePlugin.groovy
+++ b/buildSrc/src/main/groovy/eclipsebuild/TestBundlePlugin.groovy
@@ -221,6 +221,7 @@ class TestBundlePlugin implements Plugin<Project> {
                         "-bundles", p.tasks.jar.outputs.files.singleFile.path,
                         "-publishArtifacts",
                         "-nosplash",
+                        '-vm', System.getProperty('java.home') + '/bin/java',
                         "-consoleLog")
             }
         }
@@ -235,6 +236,7 @@ class TestBundlePlugin implements Plugin<Project> {
                     "-bundles", project.jar.outputs.files.singleFile.path,
                     "-publishArtifacts",
                     "-nosplash",
+                    '-vm', System.getProperty('java.home') + '/bin/java',
                     "-consoleLog")
         }
     }
@@ -255,6 +257,7 @@ class TestBundlePlugin implements Plugin<Project> {
                         '-p2.arch', Constants.arch,
                         '-roaming',
                         '-nosplash',
+                        '-vm', System.getProperty('java.home') + '/bin/java',
                         '-consoleLog')
             }
         }
@@ -272,6 +275,7 @@ class TestBundlePlugin implements Plugin<Project> {
                     '-p2.ws', Constants.ws,
                     '-p2.arch', Constants.arch,
                     '-roaming',
+                    '-vm', System.getProperty('java.home') + '/bin/java',
                     '-nosplash')
         }
     }

--- a/buildSrc/src/main/groovy/eclipsebuild/UpdateSitePlugin.groovy
+++ b/buildSrc/src/main/groovy/eclipsebuild/UpdateSitePlugin.groovy
@@ -338,6 +338,7 @@ class UpdateSitePlugin implements Plugin<Project> {
                     '-publishArtifacts',
                     '-reusePack200Files',
                     '-configs', 'ANY',
+                    '-vm', System.getProperty('java.home') + '/bin/java',
                     '-consoleLog')
         }
 
@@ -350,6 +351,7 @@ class UpdateSitePlugin implements Plugin<Project> {
                     '-metadataRepository', repositoryDir.toURI().toURL(),
                     '-categoryDefinition',  project.updateSite.siteDescriptor.toURI().toURL(),
                     '-compress',
+                    '-vm', System.getProperty('java.home') + '/bin/java',
                     '-consoleLog')
         }
 

--- a/buildSrc/src/main/groovy/eclipsebuild/jar/CreateP2RepositoryTask.groovy
+++ b/buildSrc/src/main/groovy/eclipsebuild/jar/CreateP2RepositoryTask.groovy
@@ -25,6 +25,7 @@ class CreateP2RepositoryTask extends DefaultTask {
                 '-artifactRepository', targetRepositoryDir.toURI().toURL(),
                 '-source', bundleSourceDir,
                 '-publishArtifacts',
+                '-vm', System.getProperty('java.home') + '/bin/java',
                 '-configs', 'ANY')
         }
     }

--- a/org.eclipse.buildship.site/build.gradle
+++ b/org.eclipse.buildship.site/build.gradle
@@ -2,7 +2,9 @@ apply plugin: eclipsebuild.UpdateSitePlugin
 apply plugin: 'org.hidetake.ssh'
 
 buildscript {
-    repositories { jcenter() }
+    repositories {
+        gradlePluginPortal()
+    }
     dependencies {
         classpath 'org.hidetake:gradle-ssh-plugin:2.10.1'
     }


### PR DESCRIPTION
Pins the vm used for eclipse invocations used during the build to the vm used to run gradle. This fixes issues due to incorrectly picked JVM, which result in issues like this:

![image (12)](https://github.com/user-attachments/assets/55f6a892-9407-4b10-9bbe-43c3ac8cf432)
