### PR TITLE
Configured the correct secret in GHA for DV key

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Build with Gradle
         run: ./gradlew build -x eclipseTest '-Pbuild.invoker=ci'


### PR DESCRIPTION
Configured the correct secret in GHA for DV key

Fixes build scans not publishing from Github Actions workflow.


