### PR TITLE
Configured the remote cache

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 // publish build scans from CI builds
 plugins {
-    id "com.gradle.develocity" version "3.19"
-    //id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
+    id "com.gradle.develocity" version "3.19.2"
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.1'
 }
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ develocity {
     server = "https://develocity-staging.eclipse.org"
     allowUntrustedServer = false // ensure a trusted certificate is configured
     buildScan {
+        publishing.onlyIf { it.isAuthenticated() }
         obfuscation {
             username { name -> isCI ? 'ci' : 'local' }
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0" } }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,6 @@ develocity {
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0" } }
             externalProcessName { processName -> "non-build-process" }
             hostname { host -> isCI ? 'ci' : 'local' }
-
         }
         uploadInBackground = !isCI
     }
@@ -50,25 +49,14 @@ include ':org.eclipse.buildship.oomph.edit'
 include ':org.eclipse.buildship.oomph.feature'
 include ':org.eclipse.buildship.oomph.test'
 
-// Use local build cache on developer machine and remote cache on CI
-String cacheUrl = System.getProperty('gradle.cache.remote.url', '')
-String cacheUser = System.getProperty('gradle.cache.remote.username', '')
-String cachePassword = System.getProperty('gradle.cache.remote.password', '')
-boolean remoteCacheAvailable = cacheUrl != '' && cacheUrl != '' && cachePassword != ''
-
 buildCache {
     local {
-        enabled = !remoteCacheAvailable
+        enabled = !isCI
     }
 
-    if (remoteCacheAvailable) {
-        remote(HttpBuildCache) {
-            url = cacheUrl
-            credentials {
-                username = cacheUser
-                password = cachePassword
-                push = true
-            }
-        }
+    remote(develocity.buildCache) {
+        enabled = true
+        push = isCI
     }
+
 }


### PR DESCRIPTION
Configured the remote cache for usage with https://develocity-staging.eclipse.org/.

I also added the CCUD plugin back and bumped the Develocity plugin version to latest and configured to only publish scans if authenticated.

