### PR TITLE
Implemented the full CI pipelines in Github Actions

### DIFF
--- a/.github/actions/run-build/action.yml
+++ b/.github/actions/run-build/action.yml
@@ -20,11 +20,6 @@ inputs:
     required: false
     description: "Forced Java version to use"
 
-  java-dist:
-    required: false
-    description: "Java distribution to use"
-    default: "temurin"
-
 runs:
   using: "composite"
   steps:
@@ -39,19 +34,23 @@ runs:
       run: |-
         if [[ -n "${{ inputs.java }}" ]]; then
           echo "java=${{ inputs.java }}" >> "$GITHUB_OUTPUT"
-        else
-          [[ $(echo "${{ steps.eclipse-version.outputs.formatted }}  < 425" | bc -l) -eq 1 ]] && echo "java=11"  >> "$GITHUB_OUTPUT" || echo "java=17"  >> "$GITHUB_OUTPUT"
+        elif [[ $(echo "${{ steps.eclipse-version.outputs.formatted }}  < 417" | bc -l) -eq 1 ]]; then
+          echo "java=8"  >> "$GITHUB_OUTPUT" 
+        elif [[ $(echo "${{ steps.eclipse-version.outputs.formatted }}  < 425" | bc -l) -eq 1 ]]; then
+          echo "java=11"  >> "$GITHUB_OUTPUT" || echo "java=17"  >> "$GITHUB_OUTPUT"
+        else 
+          echo "java=17"  >> "$GITHUB_OUTPUT"
         fi
 
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: ${{ steps.java-version.outputs.java }}
-        distribution: ${{ inputs.java-dist }}
+        java-version: 11
+        distribution: "temurin"
 
     - run: echo "Run ${{ inputs.name }} with Eclipse ${{ inputs.eclipse }} and Java ${{ steps.java-version.outputs.java }} on ${{ inputs.os }}"
       shell: bash
 
     - name: Run build
       shell: bash
-      run: ./gradlew ${{ inputs.command }} -Peclipse.version=${{ steps.eclipse-version.outputs.formatted }} -Pbuild.invoker=CI --info --stacktrace
+      run: ./gradlew ${{ inputs.command }} -Peclipse.version=${{ steps.eclipse-version.outputs.formatted }} -Peclipse.test.java.version=${{ steps.java-version.outputs.java }} -Pbuild.invoker=CI --info --stacktrace

--- a/.github/actions/run-build/action.yml
+++ b/.github/actions/run-build/action.yml
@@ -54,4 +54,4 @@ runs:
 
     - name: Run build
       shell: bash
-      run: echo ./gradlew ${{ inputs.command }} -Peclipse.version=${{ steps.eclipse-version.outputs.formatted }} -Pbuild.invoker=CI --info --stacktrace
+      run: ./gradlew ${{ inputs.command }} -Peclipse.version=${{ steps.eclipse-version.outputs.formatted }} -Pbuild.invoker=CI --info --stacktrace

--- a/.github/actions/run-build/action.yml
+++ b/.github/actions/run-build/action.yml
@@ -1,0 +1,57 @@
+name: "Run Gradle build"
+inputs:
+  name:
+    required: true
+    description: "Name of the action"
+
+  eclipse:
+    required: true
+    description: "Eclipse version to use"
+
+  os:
+    required: true
+    description: "Operating system to use"
+
+  command:
+    required: true
+    description: "Gradle command(s) to run"
+
+  java:
+    required: false
+    description: "Forced Java version to use"
+
+  java-dist:
+    required: false
+    description: "Java distribution to use"
+    default: "temurin"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Format Eclipse version
+      id: eclipse-version
+      shell: bash
+      run: ECLIPSE_VERSION=${{ inputs.eclipse }} && echo "formatted=${ECLIPSE_VERSION//.}" >> "$GITHUB_OUTPUT"
+
+    - name: Calculate Java distribution
+      id: java-version
+      shell: bash
+      run: |-
+        if [[ -n "${{ inputs.java }}" ]]; then
+          echo "java=${{ inputs.java }}" >> "$GITHUB_OUTPUT"
+        else
+          [[ $(echo "${{ steps.eclipse-version.outputs.formatted }}  < 425" | bc -l) -eq 1 ]] && echo "java=11"  >> "$GITHUB_OUTPUT" || echo "java=17"  >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ steps.java-version.outputs.java }}
+        distribution: ${{ inputs.java-dist }}
+
+    - run: echo "Run ${{ inputs.name }} with Eclipse ${{ inputs.eclipse }} and Java ${{ steps.java-version.outputs.java }} on ${{ inputs.os }}"
+      shell: bash
+
+    - name: Run build
+      shell: bash
+      run: echo ./gradlew ${{ inputs.command }} -Peclipse.version=${{ steps.eclipse-version.outputs.formatted }} -Pbuild.invoker=CI --info --stacktrace

--- a/.github/scripts/generate_eclipse_versions.py
+++ b/.github/scripts/generate_eclipse_versions.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+
+def generate_versions(start, end):
+    """
+    Generates a list of versions between start and end, inclusive.
+
+    Args:
+      start: The starting version (e.g., "4.8").
+      end: The ending version (e.g., "4.34").
+
+    Returns:
+      A list of versions as strings.
+    """
+
+    start_parts = list(map(int, start.split('.')))
+    end_parts = list(map(int, end.split('.')))
+    current_parts = start_parts[:]  # Create a copy
+
+    versions = []
+    while current_parts[0] < end_parts[0] or (current_parts[0] == end_parts[0] and current_parts[1] <= end_parts[1]):
+        versions.append(f"{current_parts[0]}.{current_parts[1]}")
+
+        current_parts[1] += 1
+    return versions
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python script.py <start_version> <end_version>")
+        sys.exit(1)
+
+    start = sys.argv[1]
+    end = sys.argv[2]
+    result = generate_versions(start, end)
+    print(json.dumps(result))

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,12 +6,8 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+  sanity-check:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 8
@@ -19,14 +15,60 @@ jobs:
         with:
           java-version: 8
           distribution: "zulu"
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
-        with:
-          java-version: 11
-          distribution: "temurin"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-      - name: Build with Gradle
-        run: ./gradlew build -x eclipseTest '-Pbuild.invoker=ci'
+      - name: Sanity check
+        run: ./gradlew clean assemble checkstyleMain -Peclipse.version=434 -Pbuild.invoker=CI --info --stacktrace
+  basic-test:
+    needs: sanity-check
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        include:
+          - eclipse: 48
+            java: 8
+          - eclipse: 434
+            java: 17
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: "zulu"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - name: Basic test coverage with Eclipse ${{ matrix.eclipse }} and Java ${{ matrix.java }} on ${{ matrix.os }}
+        run: ./gradlew clean assemble checkstyleMain -Peclipse.version=${{ matrix.eclipse }} -Pbuild.invoker=CI --info --stacktrace
+      
+#  build:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os: [ubuntu-latest, windows-latest]
+#    runs-on: ${{ matrix.os }}
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Set up JDK 8
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: 8
+#          distribution: "zulu"
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: 11
+#          distribution: "temurin"
+#      - name: Setup Gradle
+#        uses: gradle/actions/setup-gradle@v4
+#        with:
+#          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+#      - name: Build with Gradle
+#        run: ./gradlew build -x eclipseTest '-Pbuild.invoker=ci'
+

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - feature/ghaMigration
   pull_request:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -94,30 +94,3 @@ jobs:
           eclipse: ${{ matrix.eclipse }}
           java: ${{ matrix.java }}
           java-dist: "liberica"
-
-
-#  build:
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os: [ubuntu-latest, windows-latest]
-#    runs-on: ${{ matrix.os }}
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Set up JDK 8
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: 8
-#          distribution: "zulu"
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: 11
-#          distribution: "temurin"
-#      - name: Setup Gradle
-#        uses: gradle/actions/setup-gradle@v4
-#        with:
-#          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-#      - name: Build with Gradle
-#        run: ./gradlew build -x eclipseTest '-Pbuild.invoker=ci'
-

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - feature/ghaMigration
   pull_request:
   workflow_dispatch:
 jobs:
@@ -10,43 +11,90 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 8
-        uses: actions/setup-java@v4
-        with:
-          java-version: 8
-          distribution: "zulu"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-      - name: Sanity check
-        run: ./gradlew clean assemble checkstyleMain -Peclipse.version=434 -Pbuild.invoker=CI --info --stacktrace
+      - uses: ./.github/actions/run-build
+        with:
+          name: "Sanity check"
+          os: "ubuntu-latest"
+          command: "clean assemble checkstyleMain"
+          eclipse: "4.34"
   basic-test:
     needs: sanity-check
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        include:
-          - eclipse: 48
-            java: 8
-          - eclipse: 434
-            java: 17
+        eclipse: ["4.8", "4.34"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: "zulu"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-      - name: Basic test coverage with Eclipse ${{ matrix.eclipse }} and Java ${{ matrix.java }} on ${{ matrix.os }}
-        run: ./gradlew clean assemble checkstyleMain -Peclipse.version=${{ matrix.eclipse }} -Pbuild.invoker=CI --info --stacktrace
-      
+      - uses: ./.github/actions/run-build
+        with:
+          name: "Basic test coverage"
+          command: "clean eclipseTest"
+          os: ${{ matrix.os }}
+          eclipse: ${{ matrix.eclipse }}
+  full-test:
+    needs: basic-test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        eclipse: ['4.8', '4.9', '4.10', '4.11', '4.12', '4.13', '4.14', '4.15', '4.16', '4.17', '4.18', '4.19', '4.20', '4.21', '4.22', '4.23', '4.24', '4.25', '4.26', '4.27', '4.28', '4.29', '4.30', '4.31', '4.32', '4.33', '4.34']
+        include:
+          - os: windows-latest
+            eclipse: "4.8"
+          - os: windows-latest
+            eclipse: "4.34"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - uses: ./.github/actions/run-build
+        with:
+          name: "Full test coverage"
+          command: "clean build"
+          os: ${{ matrix.os }}
+          eclipse: ${{ matrix.eclipse }}
+  cross-version-test:
+    needs: full-test
+    strategy:
+      fail-fast: false
+      matrix:
+        eclipse: ["4.23"]
+        java: ["11", "12", "13", "14", "15", "16", "17"]
+        include:
+          - eclipse: "4.8"
+            java: "11"
+          - eclipse: "4.34"
+            java: "17"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - uses: ./.github/actions/run-build
+        with:
+          name: "Cross-version test coverage"
+          command: "clean crossVersionEclipseTest"
+          os: "ubuntu-latest"
+          eclipse: ${{ matrix.eclipse }}
+          java: ${{ matrix.java }}
+          java-dist: "liberica"
+
+
 #  build:
 #    strategy:
 #      fail-fast: false

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,6 +5,8 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
 jobs:
   sanity-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,12 +1,16 @@
 name: CI
+
 on:
   push:
     branches:
       - master
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"
+
+env:
+  ECLIPSE_LATEST: "4.34"
+
 jobs:
   sanity-check:
     runs-on: ubuntu-latest
@@ -15,82 +19,97 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
       - uses: ./.github/actions/run-build
         with:
           name: "Sanity check"
           os: "ubuntu-latest"
           command: "clean assemble checkstyleMain"
-          eclipse: "4.34"
+          eclipse: ${{ env.ECLIPSE_LATEST }}
+
+  matrix-compute:
+    runs-on: ubuntu-latest
+    outputs:
+      allEclipseVersions: ${{ steps.versions.outputs.allEclipseVersions }}
+      latestEclipse: ${{ steps.versions.outputs.latestEclipse }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: versions
+        run: |
+          versions=$(./.github/scripts/generate_eclipse_versions.py "4.8" "${{ env.ECLIPSE_LATEST }}")
+          echo "allEclipseVersions=${versions}" >> "$GITHUB_OUTPUT"
+          echo 'latestEclipse="${{ env.ECLIPSE_LATEST }}"' >> "$GITHUB_OUTPUT"
+
   basic-test:
-    needs: sanity-check
+    needs:
+      - sanity-check
+      - matrix-compute
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        eclipse: ["4.8", "4.34"]
+        eclipse: ["4.8",  "${{ needs.matrix-compute.outputs.latestEclipse }}"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
       - uses: ./.github/actions/run-build
         with:
           name: "Basic test coverage"
           command: "clean eclipseTest"
           os: ${{ matrix.os }}
           eclipse: ${{ matrix.eclipse }}
+
   full-test:
-    needs: basic-test
+    needs:
+      - basic-test
+      - matrix-compute
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        eclipse: ['4.8', '4.9', '4.10', '4.11', '4.12', '4.13', '4.14', '4.15', '4.16', '4.17', '4.18', '4.19', '4.20', '4.21', '4.22', '4.23', '4.24', '4.25', '4.26', '4.27', '4.28', '4.29', '4.30', '4.31', '4.32', '4.33', '4.34']
+        eclipse: ${{ fromJSON(needs.matrix-compute.outputs.allEclipseVersions) }}
         include:
           - os: windows-latest
             eclipse: "4.8"
           - os: windows-latest
-            eclipse: "4.34"
+            eclipse: "${{ needs.matrix-compute.outputs.latestEclipse }}"
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
       - uses: ./.github/actions/run-build
         with:
           name: "Full test coverage"
           command: "clean build"
           os: ${{ matrix.os }}
           eclipse: ${{ matrix.eclipse }}
+
   cross-version-test:
-    needs: full-test
+    needs:
+      - full-test
+      - matrix-compute
     strategy:
       fail-fast: false
       matrix:
-        eclipse: ["4.23"]
-        java: ["11", "12", "13", "14", "15", "16", "17"]
-        include:
-          - eclipse: "4.8"
-            java: "11"
-          - eclipse: "4.34"
-            java: "17"
+        eclipse: ["4.8", "4.16", "4.17", "4.24", "4.25", "${{ needs.matrix-compute.outputs.latestEclipse }}"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
       - uses: ./.github/actions/run-build
         with:
           name: "Cross-version test coverage"
           command: "clean crossVersionEclipseTest"
           os: "ubuntu-latest"
           eclipse: ${{ matrix.eclipse }}
-          java: ${{ matrix.java }}
-          java-dist: "liberica"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,83 @@
+name: PR
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  ECLIPSE_LATEST: "4.34"
+
+jobs:
+  sanity-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+      - uses: ./.github/actions/run-build
+        with:
+          name: "Sanity check"
+          os: "ubuntu-latest"
+          command: "clean assemble checkstyleMain"
+          eclipse: ${{ env.ECLIPSE_LATEST }}
+
+  matrix-compute:
+    runs-on: ubuntu-latest
+    outputs:
+      latestEclipse: ${{ steps.versions.outputs.latestEclipse }}
+    steps:
+      - id: versions
+        run: echo 'latestEclipse="${{ env.ECLIPSE_LATEST }}"' >> "$GITHUB_OUTPUT"
+
+  basic-test:
+    needs:
+      - sanity-check
+      - matrix-compute
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        eclipse: ["4.8", "${{ needs.matrix-compute.outputs.latestEclipse }}"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+      - uses: ./.github/actions/run-build
+        with:
+          name: "Basic test coverage"
+          command: "clean eclipseTest"
+          os: ${{ matrix.os }}
+          eclipse: ${{ matrix.eclipse }}
+
+  full-test:
+    needs:
+      - basic-test
+      - matrix-compute
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        eclipse: ["4.8", "4.16", "4.17", "4.24", "4.25", "${{ needs.matrix-compute.outputs.latestEclipse }}"]
+        include:
+          - os: windows-latest
+            eclipse: "4.8"
+          - os: windows-latest
+            eclipse: "${{ needs.matrix-compute.outputs.latestEclipse }}"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+      - uses: ./.github/actions/run-build
+        with:
+          name: "Full test coverage"
+          command: "clean build"
+          os: ${{ matrix.os }}
+          eclipse: ${{ matrix.eclipse }}


### PR DESCRIPTION
Implemented the full CI pipelines in Github Actions.

The strategy is as follows:

1. PRs + manual: 
    1. **sanity check** with Eclipse latest on Linux
    2. **basic test matrix**: Eclipse 4.8(earliest) and latest on Linux and Windows
    3. **full test matrix**: earliest and latest Eclipse version for each of the test Java versions (8, 11, 17) on Linux + Eclipse 4.8(earliest) and latest on Windows
2. Post-merge and nightly + manual: 
    1. **sanity check** with Eclipse latest on Linux
    2. **basic test matrix**: Eclipse 4.8(earliest) and latest on Linux and Windows
    3. **full test matrix**: all Eclipse versions from 4.8(earliest) to latest (varied test Java versions) on Linux + Eclipse 4.8(earliest) and latest on Windows
    4. **cross version test matrix**: earliest and latest Eclipse version for each of the test Java versions (8, 11, 17) on Linux 

The latest eclipse version is "hardcoded" in each workflow env var so it's easier to update.

Note: The strategy was discussed and agreed upon with @donat before implementation. 