### PR TITLE
Added build scan tags for eclipse and eclipse test java versions set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,8 +77,7 @@ eclipseBuild {
 
 def develocityApi = project.extensions.findByName('develocity')
 if (develocityApi) {
-    def version = Config.on(project).getEclipseVersion()
-    def eclipseVersion = version.substring(0, 1) + "." + version.substring(1)
+    def eclipseVersion = Config.on(project).getTargetPlatform().getEclipseVersion()
     develocityApi.getBuildScan().tag("eclipse_${eclipseVersion}")
     if (project.hasProperty('eclipse.test.java.version')) {
         develocityApi.getBuildScan().tag("eclipseTestJdk_${project.getProperty('eclipse.test.java.version')}")

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,9 @@ if (develocityApi) {
     def version = Config.on(project).getEclipseVersion()
     def eclipseVersion = version.substring(0, 1) + "." + version.substring(1)
     develocityApi.getBuildScan().tag("eclipse_${eclipseVersion}")
+    if (project.hasProperty('eclipse.test.java.version')) {
+        develocityApi.getBuildScan().tag("eclipseTestJdk_${project.getProperty('eclipse.test.java.version')}")
+    }
 }
 
 // read the current version from an external file and add a timestamp suffix if requested by the caller

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,13 @@ eclipseBuild {
     commitId = currentCommitId()
 }
 
+def develocityApi = project.extensions.findByName('develocity')
+if (develocityApi) {
+    def version = Config.on(project).getEclipseVersion()
+    def eclipseVersion = version.substring(0, 1) + "." + version.substring(1)
+    develocityApi.getBuildScan().tag("eclipse_${eclipseVersion}")
+}
+
 // read the current version from an external file and add a timestamp suffix if requested by the caller
 ext.baseVersion = file('version.txt').text.trim()
 ext.versionQualifier = getVersionQualifier()


### PR DESCRIPTION
Added build scan tags for eclipse and eclipse test java versions set. This will make it easier to discern different builds, as well as filter them in Develocity.