### PR TITLE
Increased the eclipseJob timeout in EclipseTestExecutor to 30s

### DIFF
--- a/buildSrc/src/main/groovy/eclipsebuild/testing/EclipseTestExecuter.java
+++ b/buildSrc/src/main/groovy/eclipsebuild/testing/EclipseTestExecuter.java
@@ -225,7 +225,7 @@ public final class EclipseTestExecuter implements TestExecuter<TestExecutionSpec
         }
 
         try {
-            eclipseJob.get(15, TimeUnit.SECONDS);
+            eclipseJob.get(30, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new GradleException("Test execution failed", e);
         }


### PR DESCRIPTION
Increased the eclipseJob timeout in EclipseTestExecutor to 30s. This will hopefully prevent flaky test failures, such as [this](https://github.com/eclipse-buildship/buildship/actions/runs/13788583228/job/38562562180?pr=1330).