### PR TITLE
Fix for correct GHA Develocity key scret name

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Sanity check"
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Basic test coverage"
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Full test coverage"
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Cross-version test coverage"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Sanity check"
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Basic test coverage"
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Full test coverage"


### PR DESCRIPTION
Fix for correct GHA Develocity key scret name. This fixes not being able to publish build scans because of the wrong secret name set in GHA workflow files. It was `DEVELOCITY_API_KEY` instead of `DEVELOCITY_API_TOKEN`, which is what is (now) [configured](https://github.com/eclipse-buildship/.eclipsefdn/pull/2/files).