### PR TITLE
Let TAPI connection carry contextual system properties

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/ToolingApiSystemPropertiesTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/ToolingApiSystemPropertiesTest.groovy
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Gradle Inc. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.buildship.core.internal
+
+import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+import org.eclipse.buildship.core.internal.ToolingApiSystemProperties
+import org.eclipse.buildship.core.SynchronizationResult
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.gradle.tooling.ProjectConnection
+
+class ToolingApiSystemPropertiesTest extends ProjectSynchronizationSpecification {
+
+
+    def "any tooling api interaction provides buildship dot active system property"() {
+		given:
+        File location = dir('under-test-build')  {
+	        file 'settings.gradle', """
+	            def active = "${ToolingApiSystemProperties.ACTIVE_NAME}"
+	        	if (System.getProperty("\$active") != "true") {
+                    throw new Exception("UNSET PROPERTY: \$active")
+                }
+        	"""
+        }
+
+
+       	expect:
+       	def gradleBuild = gradleBuildFor(location)
+        def query = { ProjectConnection c -> c.newBuild().forTasks("help").run(); true }
+       	gradleBuild.withConnection(query, new NullProgressMonitor());
+	}
+
+	def "ide synchronization provides buildship dot sync dot active system property"() {
+		given:
+        File location = dir('under-test-build')  {
+	        file 'settings.gradle', """
+	            def active = "${ToolingApiSystemProperties.ACTIVE_NAME}"
+	            def activeSync = "${ToolingApiSystemProperties.SYNC_ACTIVE_NAME}"
+                if (System.getProperty("\$active") != "true") {
+                    throw new Exception("UNSET PROPERTY: \$active")
+                }
+	        	if (System.getProperty("\$activeSync") != "true") {
+                    throw new Exception("UNSET PROPERTY: \$activeSync")
+                }
+        	"""
+        }
+
+       	when:
+       	def gradleBuild = gradleBuildFor(location)
+        SynchronizationResult result = gradleBuild.synchronize(null)
+
+        then:
+        assertResultOkStatus(result)
+    }
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/CorePlugin.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/CorePlugin.java
@@ -111,21 +111,21 @@ public final class CorePlugin extends Plugin {
     private ToolingApiOperationManager operationManager;
     private ExtensionManager extensionManager;
     
-    private String originalActive;
+    private String originalActiveSystemProperty;
 
     @Override
     public void start(BundleContext bundleContext) throws Exception {
         super.start(bundleContext);
         plugin = this;
         ensureProxySettingsApplied();
-        originalActive = ToolingApiSystemProperties.overrideActive();
+        originalActiveSystemProperty = ToolingApiSystemProperties.overrideActive();
         registerServices(bundleContext);
         scheduleSynchronizationForAbsentModels();
     }
 
     @Override
     public void stop(BundleContext context) throws Exception {
-        ToolingApiSystemProperties.restoreActive(originalActive);
+        ToolingApiSystemProperties.restoreActive(originalActiveSystemProperty);
         unregisterServices();
         IdeFriendlyClassLoading.cleanup();
         plugin = null;

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/CorePlugin.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/CorePlugin.java
@@ -110,18 +110,22 @@ public final class CorePlugin extends Plugin {
     private DefaultExternalLaunchConfigurationManager externalLaunchConfigurationManager;
     private ToolingApiOperationManager operationManager;
     private ExtensionManager extensionManager;
+    
+    private String originalActive;
 
     @Override
     public void start(BundleContext bundleContext) throws Exception {
         super.start(bundleContext);
         plugin = this;
         ensureProxySettingsApplied();
+        originalActive = ToolingApiSystemProperties.overrideActive();
         registerServices(bundleContext);
         scheduleSynchronizationForAbsentModels();
     }
 
     @Override
     public void stop(BundleContext context) throws Exception {
+        ToolingApiSystemProperties.restoreActive(originalActive);
         unregisterServices();
         IdeFriendlyClassLoading.cleanup();
         plugin = null;

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/ToolingApiSystemProperties.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/ToolingApiSystemProperties.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Gradle Inc. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.buildship.core.internal;
+
+public final class ToolingApiSystemProperties {
+
+    public static interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    static final String ACTIVE_NAME = "buildship.active";
+    static final String SYNC_ACTIVE_NAME = "buildship.sync.active";
+
+    /**
+     * Sets the {@code buildship.active} system property to {@code "true"}.
+     * 
+     * @return the original value of the {@code buildship.active} system property,
+     *         to be passed to {@link #restoreActive(String)}.
+     */
+    public static String overrideActive() {
+        return overrideProperty(ACTIVE_NAME, "true");
+    }
+
+    /**
+     * Restores the {@code buildship.active} system property to its original value.
+     * 
+     * @param originalValue the original value of the {@code buildship.active}
+     *                      system property obtained from {@link #overrideActive()}.
+     */
+    public static void restoreActive(String originalValue) {
+        restoreProperty(ACTIVE_NAME, originalValue);
+    }
+
+    /**
+     * Runs the given code with the {@code buildship.sync.active} system property
+     * set to {@code "true"}.
+     * 
+     * @param <T>      the type of return produced by {@code runnable}
+     * @param runnable the code to run with the system property set
+     * @throws Exception when {@code runnable} throws
+     */
+    public static void withSyncActive(ThrowingRunnable runnable) throws Exception {
+        withSystemProperty(SYNC_ACTIVE_NAME, "true", runnable);
+    }
+
+    private static synchronized void withSystemProperty(String propertyName, String value, ThrowingRunnable runnable)
+            throws Exception {
+        String originalValue = overrideProperty(propertyName, value);
+        try {
+            runnable.run();
+        } finally {
+            restoreProperty(propertyName, originalValue);
+        }
+    }
+
+    private static String overrideProperty(String propertyName, String value) {
+        String originalValue = System.getProperty(propertyName);
+        if (value != null) {
+            System.setProperty(propertyName, value);
+        } else {
+            System.clearProperty(propertyName);
+        }
+        return originalValue;
+    }
+
+    private static void restoreProperty(String propertyName, String originalValue) {
+        if (originalValue != null) {
+            System.setProperty(propertyName, originalValue);
+        } else {
+            System.clearProperty(propertyName);
+        }
+    }
+
+    private ToolingApiSystemProperties() {
+    }
+}


### PR DESCRIPTION
`buildship.active=true` for all TAPI connections
`buildship.sync.active=true` for IDE Synchronization

<!--- The issue this PR addresses -->
Fixes #?

### Context

Just like IntelliJ based IDE set `idea.active` and `idea.sync.active` system properties on the TAPI connection, this PR let Buildship do the same.

