### PR TITLE
Revert Develocity config

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 // publish build scans from CI builds
 plugins {
-    id "com.gradle.develocity" version "3.19.2"
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.1'
+    id("com.gradle.develocity") version "4.4.0"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.4.0"
 }
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ plugins {
 def isCI = System.getenv('CI') != null
 
 develocity {
-    server = "https://develocity-staging.eclipse.org"
+    server = "https://ge.gradle.org"
     allowUntrustedServer = false // ensure a trusted certificate is configured
     buildScan {
         publishing.onlyIf { it.isAuthenticated() }


### PR DESCRIPTION
The Eclipse Foundation has announced the discontinuation of the Develocity service offering (see [announcement](https://www.eclipse.org/lists/eclipse.org-committers/msg01557.html)). 

This PR reverts to publishing scans to https://ge.gradle.org. It also upgrades the DV and CCUD plugins.
