### PR TITLE
Derive the version qualifier from a given build instant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -286,14 +286,22 @@ String getVersionQualifier() {
     String suffix = getVersionSuffix(config)
 
     // use full timestamp on CI vs. date-only for local builds
-    if (project.hasProperty('qualifier')) {
-        'v' + project.getProperty('qualifier')
-    } else if (project.hasProperty('build.invoker') && project.property('build.invoker') == 'ci') {
-        // note that for Eclipse plugin versions, the '-' and '.' character are invalid in front of the build id
-        'v' + new Date().format('yyyyMMdd-kkmm', TimeZone.getTimeZone('GMT')) + suffix
-    } else {
-        'v' + new Date().format('yyyyMMdd', TimeZone.getTimeZone('GMT')) + suffix
+    // note that for Eclipse plugin versions, the '-' and '.' character are invalid in front of the build id
+    boolean invokedByCi = project.hasProperty('build.invoker') && project.property('build.invoker') == 'ci'
+    String pattern = invokedByCi ? 'yyyyMMdd-HHmm' : 'yyyyMMdd'
+
+    'v' + resolveBuildTimestamp().format(pattern, TimeZone.getTimeZone('GMT')) + suffix
+}
+
+private Date resolveBuildTimestamp() {
+    if (!project.hasProperty('buildTimestamp')) {
+        return new Date()
     }
+    String seconds = project.getProperty('buildTimestamp').toString().trim()
+    if (!seconds.isLong()) {
+        throw new IllegalArgumentException("Invalid buildTimestamp '$seconds': expected the number of seconds since the epoch.")
+    }
+    new Date(seconds.toLong() * 1000)
 }
 
 private getVersionSuffix(BuildshipConfig config) {

--- a/org.eclipse.buildship.site/build.gradle
+++ b/org.eclipse.buildship.site/build.gradle
@@ -67,6 +67,12 @@ task uploadUpdateSite(dependsOn : createP2Repository) {
 
     onlyIf { !['36', '37'].contains(eclipsebuild.Config.on(project).targetPlatform.eclipseVersion) }
 
+    doFirst {
+        if (project.findProperty('build.invoker') == 'ci' && !project.hasProperty('buildTimestamp')) {
+            throw new GradleException("Refusing to publish without -PbuildTimestamp: the release pipeline must pass the build instant shared by all promotion builds.")
+        }
+    }
+
     doLast {
         // folder structure
         // releases                    (main folder - composite update site if release repository)


### PR DESCRIPTION
Every promotion build of a release pipeline computes its own version qualifier from the moment it happens to run. A chain walks through 33 Eclipse version streams one after the other and takes hours, so one release gets published as `3.1.12.v20260908-0412` in one stream and as `3.1.12.v20260908-0631` in the next. `uploadUpdateSite` names the remote folder after `project.version`, so the same bits end up under a different folder name in every stream.

The qualifier is now derived from an instant the caller supplies with `-PbuildTimestamp`, as seconds since the epoch. The release pipeline determines it once per promotion chain and hands the same value to every promotion build in it (companion change in the TeamCity configuration: https://github.com/gradle/buildship/pull/4). Passing nothing keeps the previous behaviour and uses the moment the build started, so local builds are unaffected.

This replaces `-Pqualifier`, which injected a whole qualifier string and skipped the release type suffix on the way, so a milestone promoted that way was published without its `-m` marker. Nothing in this repository or in the CI configuration used it.

`uploadUpdateSite` now refuses to publish from CI unless it was handed an instant. Silently falling back to the current time is exactly what produced the mismatched folder names, and that fallback is invisible until someone looks at the download server.

Also switches the CI pattern from `kkmm` to `HHmm`. `kk` renders midnight as hour 24, which sorts after every other hour of the same day and breaks the ordering p2 relies on to recognise a newer version.

## Verification

Version numbers printed through `properties`, before and after:

| properties | before | after |
| --- | --- | --- |
| none | `3.1.12.v20260908-s` | `3.1.12.v20260908-s` |
| `build.invoker=ci` | `3.1.12.v20260908-0829-s` | `3.1.12.v20260908-0830-s` |
| `release.type=milestone` | `3.1.12.v20260908-m` | `3.1.12.v20260908-m` |
| `release.type=release` | `3.1.12.v20260908` | `3.1.12.v20260908` |
| `buildTimestamp=1757340000`, ci | n/a | `3.1.12.v20250908-1400-s` |
| `buildTimestamp=1757340000`, ci, milestone | n/a | `3.1.12.v20250908-1400-m` |
| `buildTimestamp=1757340000`, ci, release | n/a | `3.1.12.v20250908-1400` |
| `qualifier=20260908-1432` | `3.1.12.v20260908-1432` | `3.1.12.v20260908-s` (ignored) |

The last three rows are the point: one instant, three release types, differing only in the suffix. Before this change all three `qualifier=` rows produced the same string regardless of release type.

`-PbuildTimestamp=notanumber` and `-PbuildTimestamp=` (an unresolved CI parameter would arrive empty) both fail with `Invalid buildTimestamp ...: expected the number of seconds since the epoch.` rather than falling back to the current time.

The publish guard was exercised with `uploadUpdateSite` against a dummy host: refused with `build.invoker=ci` and no instant, and got as far as the SSH connection both with an instant and on a local build.

No test scenario runs `uploadUpdateSite` - `SANITY_CHECK` is `assemble checkstyleMain`, `BASIC_COVERAGE` is `clean eclipseTest`, `FULL_COVERAGE` is `clean build`, `CROSS_VERSION` is `clean crossVersionEclipseTest`, and nothing depends on the task - so the guard cannot fire outside a promotion build.
