### PR TITLE
Write JUnit XML from eclipseTest

### DIFF
--- a/buildSrc/src/main/groovy/eclipsebuild/testing/EclipseTestTask.java
+++ b/buildSrc/src/main/groovy/eclipsebuild/testing/EclipseTestTask.java
@@ -17,6 +17,7 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
@@ -36,11 +37,16 @@ public abstract class EclipseTestTask extends JavaExec {
 
     private static final Logger LOGGER = Logging.getLogger(EclipseTestTask.class);
 
+    private static final String BINARY_RESULTS_DIR_NAME = "binary";
+
     @Inject
     protected abstract TestEventReporterFactory getTestEventReporterFactory();
 
     @Inject
     protected abstract ExecFactory getExecFactory();
+
+    @Inject
+    protected abstract ObjectFactory getObjectFactory();
 
     @OutputDirectory
     public abstract DirectoryProperty getTestEclipseDirectory();
@@ -192,16 +198,26 @@ public abstract class EclipseTestTask extends JavaExec {
         remoteTestRunnerClient.startListening(new ITestRunListener2[] { pdeTestListener }, pdeTestPort);
         LOGGER.info("Listening on port {} for Eclipse Integration Test results in project {}...", pdeTestPort, getProject().getName());
 
+        Directory testResultsDir = cleanDirectory("test-results/" + getName());
+        Directory binaryResultsDir = testResultsDir.dir(BINARY_RESULTS_DIR_NAME);
         EclipseTestAdapter eclipseTestAdapter = new EclipseTestAdapter(
                 pdeTestListener,
                 getTestEventReporterFactory().createTestEventReporter(
                     "Eclipse Integration Test",
-                        cleanDirectory("test-results/" + getName()),
+                        binaryResultsDir,
                         cleanDirectory("reports/tests/" + getName())
                 )
         );
 
-        if(!eclipseTestAdapter.processEvents()) {
+        boolean success;
+        try {
+            success = eclipseTestAdapter.processEvents();
+        } finally {
+            JUnitXmlReport.generate(getObjectFactory(), binaryResultsDir, testResultsDir);
+            LOGGER.info("JUnit XML test results written to {}", testResultsDir);
+        }
+
+        if (!success) {
             throw new GradleException("Test execution failed");
         }
 

--- a/buildSrc/src/main/groovy/eclipsebuild/testing/JUnitXmlReport.java
+++ b/buildSrc/src/main/groovy/eclipsebuild/testing/JUnitXmlReport.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Donát Csikós (Gradle Inc.) - initial API and implementation and initial documentation
+ */
+
+package eclipsebuild.testing;
+
+import org.gradle.api.file.Directory;
+import org.gradle.api.internal.tasks.testing.TestReportGenerator;
+import org.gradle.api.internal.tasks.testing.junit.result.JUnitXmlResultOptions;
+import org.gradle.api.internal.tasks.testing.report.generic.JunitXmlTestReportGenerator;
+import org.gradle.api.model.ObjectFactory;
+
+import java.util.Collections;
+
+final class JUnitXmlReport {
+
+    private JUnitXmlReport() {
+    }
+
+    /**
+     * Writes one {@code TEST-<class name>.xml} file per test class into {@code xmlResultsDir}.
+     */
+    static void generate(ObjectFactory objectFactory, Directory binaryResultsDir, Directory xmlResultsDir) {
+        JUnitXmlResultOptions options = new JUnitXmlResultOptions(false, false, true, true);
+        TestReportGenerator generator = objectFactory.newInstance(JunitXmlTestReportGenerator.class, xmlResultsDir.getAsFile().toPath(), options);
+        generator.generate(Collections.singletonList(binaryResultsDir.getAsFile().toPath()));
+    }
+}


### PR DESCRIPTION
TeamCity shows no test names for `eclipseTest`. A failed run is just a bare Gradle exception in the UI.

The cause is the test event reporter API we moved to in 8.13. It writes binary results and an HTML report, but no JUnit XML, and the XML files are what CI servers read. Before that migration `eclipseTest` was a real `Test` task, so it got the XML for free.

Binary results move to `test-results/eclipseTest/binary` so the XML files sit where a `Test` task would put them.